### PR TITLE
Fixes #3: Support for Chrome / Chrome Driver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: python
 python: "2.7"
 
 env:
-  - ANSIBLE_VERSION=1.8
+  - ANSIBLE_VERSION=2.0
+  - ANSIBLE_VERSION=2.1
 
 before_install:
   - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Set up selenium and Firefox for running selenium tests.
 
 * `selenium_install_dir`: [default: `/opt`] Install directory
 * `selenium_version`: [default: `2.44.0`] Install version
+* `selenium_install_firefox`: [default: `yes`] Whether to install FireFox
+* `selenium_install_chrome`: [default: `no`] Whether to install Google Chrome
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for selenium
 selenium_install_dir: /opt
-selenium_version: 2.53.0
+selenium_version: "2.53.0"
 selenium_install_firefox: yes
+selenium_install_chrome: no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: Alex Knoll
   description: Set up selenium and Firefox for running selenium tests.
   license: Apache V2
-  min_ansible_version: 1.3
+  min_ansible_version: 2.0
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,42 +1,68 @@
 ---
 # Tasks file for selenium
+- name: Include OS-Specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+  tags: [configuration, selenium]
+
 - name: create directory
   file: "path={{ selenium_install_dir }}/selenium state=directory recurse=yes"
   tags: [configuration, selenium, selenium-create-directory]
 
-- name: download
-  get_url: "url=http://selenium-release.storage.googleapis.com/{{ selenium_version | regex_replace('\\.[0-9]+$', '') }}/selenium-server-standalone-{{ selenium_version }}.jar dest={{ selenium_install_dir }}/selenium/selenium-server-standalone-{{ selenium_version }}.jar"
+- name: Download Selenium
+  get_url:
+    url: "http://selenium-release.storage.googleapis.com/{{ selenium_version | regex_replace('\\.[0-9]+$', '') }}/selenium-server-standalone-{{ selenium_version }}.jar"
+    dest: "{{ selenium_install_dir }}/selenium/selenium-server-standalone-{{ selenium_version }}.jar"
   tags: [configuration, selenium, selenium-download]
 
+- name: Install FireFox (if configured)
+  package: name=firefox state=present
+  when: selenium_install_firefox
+  tags: [configuration, selenium, selenium-firefox]
+
+- name: Install Chrome (if configured, Debian)
+  apt:
+    deb: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    state: present
+  when: ansible_os_family == 'Debian' and selenium_install_chrome
+  tags: [configuration, selenium, selenium-chrome]
+
+- name: Install Chrome (if configured, RedHat)
+  yum:
+    name: https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+    state: present
+  when: ansible_os_family == 'RedHat' and selenium_install_chrome
+  tags: [configuration, selenium, selenium-chrome]
+
+- name: Get the latest release for chromedriver
+  uri:
+    url: http://chromedriver.storage.googleapis.com/LATEST_RELEASE
+    return_content: yes
+  register: chromedriver_latest
+  when: selenium_install_chrome
+  tags: [configuration, selenium, selenium-chrome]
+
+- name: Install chromedriver
+  unarchive:
+    src: "http://chromedriver.storage.googleapis.com/{{ chromedriver_latest.content | trim }}/chromedriver_linux64.zip"
+    dest: /usr/bin
+    mode: 0755
+    copy: no
+  when: selenium_install_chrome
+  tags: [configuration, selenium, selenium-chrome]
+
 - name: Install xvfb
-  apt: name={{item}}
-  with_items:
-    - xvfb
-  when: ansible_os_family == 'Debian'
+  package: name={{ selenium_xvfb_package }}
+  tags: [configuration, selenium, selenium-xvfb]
 
-- name: Install browser
-  apt: name={{item}}
-  with_items:
-    - firefox
-  when: ansible_os_family == 'Debian' and selenium_install_firefox
-
-- name: Install browser Xvfb
-  yum: name={{item}}
-  with_items:
-    - xorg-x11-server-Xvfb
-  when: ansible_os_family == 'RedHat'
-
-- name: Install browser
-  yum: name={{item}}
-  with_items:
-    - firefox
-  when: ansible_os_family == 'RedHat' and selenium_install_firefox
-
-
-- name: install
-  template: src=selenium-init-{{ ansible_os_family }}.j2 dest=/etc/init.d/selenium owner=root group=root mode=0755
+- name: Install init script
+  template:
+    src: "selenium-init-{{ ansible_os_family }}.j2"
+    dest: /etc/init.d/selenium
+    owner: root
+    group: root
+    mode: 0755
   tags: [configuration, selenium, selenium-install]
 
-- name: run
+- name: Ensure selenium is running
   service: name=selenium state=started enabled=yes
   tags: [configuration, selenium, selenium-run]

--- a/templates/selenium-init-Debian.j2
+++ b/templates/selenium-init-Debian.j2
@@ -1,4 +1,13 @@
 #!/bin/bash
+### BEGIN INIT INFO
+# Provides:          selenium
+# Required-Start:    $local_fs $network
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: selenium
+# Description:       selenium test framework
+### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+selenium_xvfb_package: xvfb

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+selenium_xvfb_package: xorg-x11-server-Xvfb

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for selenium


### PR DESCRIPTION
See #3.

This PR bumps the role's Ansible version requirement up to 2.0, since it also consolidates a few tasks using `package`, and also uses `archive`'s download + expand + place functionality (so that we don't have to add a bunch of extra tasks to install Chrome and Chrome Driver.

If merged, the next release should likely be a major version bump for the role (e.g. 2.0.0)...
