### PR TITLE
Fixes debian 8 and centos 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Thumbs.db
 ###############
 !empty
 /tests/test.sh
+/tests/test.retry

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Thumbs.db
 # Other files #
 ###############
 !empty
+/tests/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 *.komodoproject
 *.kpf
 /.idea
+/*.iml
 
 # Other files #
 ###############

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
 
 notifications:
   email: false
-#  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
 
 notifications:
   email: false
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+#  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
 - name: Install start script (for systemd systems)
   template:
     src: "selenium-start.j2"
-    dest: /opt/selenium/start.sh
+    dest: "{{ selenium_install_dir }}/selenium/start.sh"
     owner: root
     group: root
     mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,6 +83,16 @@
   when: "ansible_service_mgr != 'systemd'"
   tags: [configuration, selenium, selenium-install]
 
+- name: Install start script (for systemd systems)
+  template:
+    src: "selenium-start.j2"
+    dest: /opt/selenium/start.sh
+    owner: root
+    group: root
+    mode: 0755
+  when: "ansible_service_mgr == 'systemd'"
+  tags: [configuration, selenium, selenium-install]
+
 - name: Install systemd unit file (for systemd systems)
   template:
     src: "selenium-unit.j2"
@@ -105,4 +115,5 @@
   retries: 3
   delay: 5
   changed_when: false
+  tags: [configuration, selenium, selenium-run]
   when: "ansible_service_mgr == 'systemd'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,3 +104,4 @@
   until: result.stdout.find("Selenium Server is up and running") != -1
   retries: 3
   delay: 5
+  when: "ansible_service_mgr == 'systemd'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,4 +104,5 @@
   until: result.stdout.find("Selenium Server is up and running") != -1
   retries: 3
   delay: 5
+  changed_when: false
   when: "ansible_service_mgr == 'systemd'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,14 +93,14 @@
   when: "ansible_service_mgr == 'systemd'"
   tags: [configuration, selenium, selenium-install]
 
-- name: Register systemd service status (for systemd systems)
-  shell: 'systemctl status selenium | grep "active (running)"'
-  when: "ansible_service_mgr == 'systemd'"
-  register: selenium_running
-  ignore_errors: yes
-  changed_when: false
-
-- name: Ensure selenium is running
+- name: Start selenium service (for systemd systems)
   service: name=selenium state=started enabled=yes
   tags: [configuration, selenium, selenium-run]
-  when: selenium_running.failed is defined and selenium_running.failed == true
+  when: "ansible_service_mgr == 'systemd'"
+
+- name: Ensure selenium server is up and running (for systemd systems)
+  shell: 'systemctl status selenium'
+  register: result
+  until: result.stdout.find("Selenium Server is up and running") != -1
+  retries: 3
+  delay: 5

--- a/templates/selenium-start.j2
+++ b/templates/selenium-start.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/xvfb-run {{ selenium_xvfb_args }} /usr/bin/java -client -jar {{ selenium_install_dir }}/selenium/selenium-server-standalone-{{ selenium_version }}.jar

--- a/templates/selenium-unit.j2
+++ b/templates/selenium-unit.j2
@@ -3,7 +3,7 @@ Description=selenium test framework
 After=syslog.target network.target
 
 [Service]
-ExecStart=/usr/bin/xvfb-run {{ selenium_xvfb_args }} /usr/bin/java -client -jar {{ selenium_install_dir }}/selenium/selenium-server-standalone-{{ selenium_version }}.jar
+ExecStart={{ selenium_install_dir }}/selenium/start.sh
 Restart=on-failure
 RestartSec=20s
 


### PR DESCRIPTION
This role currently doesn't work on debian 8 and centos 7, because the xvfb-run call in the systemd service file has problems passing the parameters to xvfb. There is a test which should make sure the service is correctly started, but because of a timing issue (service gets started correctly but exits after some seconds) this doesn't work.
I've fixed the parameter issue by adding a new start shell script and calling that from the service file. Additionally i've added a new test which waits for the message "Selenium Server up and running"  to really make sure the server is up. 